### PR TITLE
fix: remove dead LESS client-side compilation from all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/bookworm.html
+++ b/bookworm.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/contact.html
+++ b/contact.html
@@ -45,12 +45,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700|Raleway:400,300,700,900|Open+Sans:400,300,700,800|Montserrat:400,700' rel='stylesheet' type='text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/damage.html
+++ b/damage.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/dsc-boogies.html
+++ b/dsc-boogies.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/dsc-five-reasons.html
+++ b/dsc-five-reasons.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/error404.html
+++ b/error404.html
@@ -39,12 +39,6 @@
 <link href="stylesheets/main-responsive.css" rel="stylesheet">
 <!-- Main Template Retina Optimizaton Rules -->
 <link href="stylesheets/main-retina.css" rel="stylesheet">
-<!-- LESS stylesheet for managing color presets -->
-<link rel="stylesheet/less" type="text/css" href="less/color.less">
-<!-- LESS stylesheet for managing font presets -->
-<link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-<!-- LESS JS engine-->
-<script src="less/less-1.7.3.min.js"></script>
 
 <!-- Google Web Fonts-->
 <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>

--- a/index.html
+++ b/index.html
@@ -45,12 +45,6 @@
 <link href="stylesheets/main-responsive.css" rel="stylesheet">
 <!-- Main Template Retina Optimizaton Rules -->
 <link href="stylesheets/main-retina.css" rel="stylesheet">
-<!-- LESS stylesheet for managing color presets -->
-<link rel="stylesheet/less" type="text/css" href="less/color.less">
-<!-- LESS stylesheet for managing font presets -->
-<link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-<!-- LESS JS engine-->
-<script src="less/less-1.7.3.min.js"></script>
 
 <!-- Google Web Fonts-->
 <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700|Raleway:400,300,700,900|Open+Sans:400,300,700,800|Montserrat:400,700' rel='stylesheet' type='text/css">

--- a/project-1.html
+++ b/project-1.html
@@ -45,12 +45,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700|Raleway:400,300,700,900|Open+Sans:400,300,700,800|Montserrat:400,700' rel='stylesheet' type='text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-10.html
+++ b/project-10.html
@@ -43,12 +43,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-11.html
+++ b/project-11.html
@@ -43,12 +43,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-2.html
+++ b/project-2.html
@@ -46,12 +46,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700|Raleway:400,300,700,900|Open+Sans:400,300,700,800|Montserrat:400,700' rel='stylesheet' type='text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-3.html
+++ b/project-3.html
@@ -45,12 +45,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700|Raleway:400,300,700,900|Open+Sans:400,300,700,800|Montserrat:400,700' rel='stylesheet' type='text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-4.html
+++ b/project-4.html
@@ -44,12 +44,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-5.html
+++ b/project-5.html
@@ -44,12 +44,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-7.html
+++ b/project-7.html
@@ -43,12 +43,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-8.html
+++ b/project-8.html
@@ -43,12 +43,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-9.html
+++ b/project-9.html
@@ -43,12 +43,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-dtv1.html
+++ b/project-dtv1.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-dtv2.html
+++ b/project-dtv2.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href="https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700" rel="stylesheet" type="text/css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/project-last.html
+++ b/project-last.html
@@ -37,12 +37,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/qb-payments.html
+++ b/qb-payments.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/qb-payroll.html
+++ b/qb-payroll.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/resources.html
+++ b/resources.html
@@ -38,13 +38,6 @@
 <link href="stylesheets/main-responsive.css" rel="stylesheet">
 <!-- Main Template Retina Optimizaton Rules -->
 <link href="stylesheets/main-retina.css" rel="stylesheet">
-<!-- LESS stylesheet for managing color presets -->
-<link rel="stylesheet/less" type="text/css" href="less/color.less">
-<!-- LESS stylesheet for managing font presets -->
-<link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-
-<!-- LESS JS engine-->
-<script src="less/less-1.7.3.min.js"></script>
 
 <!-- Google Web Fonts-->
 <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
@@ -164,7 +157,7 @@
                 <div class="row">
                         <article class="text-left col-md-12">
                             <h1 class="main-heading"><span class="black font5"><em class="dark font3 weight-light">Resources</em></span></h1>
-                            <h2 class="dark font3 weight-light">Tech Links & Tweets</h3>
+                            <h2 class="dark font3 weight-light">Tech Links & Tweets</h2>
                         </article>
                 </div>
             </div>

--- a/services.html
+++ b/services.html
@@ -38,12 +38,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/thanks.html
+++ b/thanks.html
@@ -39,12 +39,6 @@
 <link href="stylesheets/main-responsive.css" rel="stylesheet">
 <!-- Main Template Retina Optimizaton Rules -->
 <link href="stylesheets/main-retina.css" rel="stylesheet">
-<!-- LESS stylesheet for managing color presets -->
-<link rel="stylesheet/less" type="text/css" href="less/color.less">
-<!-- LESS stylesheet for managing font presets -->
-<link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-<!-- LESS JS engine-->
-<script src="less/less-1.7.3.min.js"></script>
 
 <!-- Google Web Fonts-->
 <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>

--- a/works-grid-0.html
+++ b/works-grid-0.html
@@ -39,12 +39,6 @@
     <link href="stylesheets/main-responsive.css" rel="stylesheet">
     <!-- Main Template Retina Optimizaton Rules -->
     <link href="stylesheets/main-retina.css" rel="stylesheet">
-    <!-- LESS stylesheet for managing color presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/color.less">
-    <!-- LESS stylesheet for managing font presets -->
-    <link rel="stylesheet/less" type="text/css" href="less/fonts.less">
-    <!-- LESS JS engine-->
-    <script src="less/less-1.7.3.min.js"></script>
     <!-- Google Web Fonts-->
     <link href='https://fonts.googleapis.com/css?family=Lato:400,100,300,400italic,300italic,700,700italic|Inconsolata:400,700%7CRaleway:400,300,700,900%7COpen+Sans:400,300,700,800%7CMontserrat:400,700' rel='stylesheet' type='text/css'>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
The less/ directory never existed, causing 3x 404 console errors on every page. Styles were already compiled into less-compiled.css. Also fixes mismatched h2/h3 closing tag in resources.html.