### PR TITLE
fix: remove missing ferris.jpg backstretch call from about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -241,24 +241,15 @@
     <script src="javascripts/libs/device.min.js"></script>
     <script src="javascripts/libs/classie.js"></script>
     <script src="javascripts/libs/jquery.touchSwipe.js"></script>
-    <script src="javascripts/libs/jquery.backstretch.min.js"></script>
     <script src="javascripts/libs/jquery.meanmenu.js"></script>
     <script src="javascripts/libs/equalheights.js"></script>
+    <script src="javascripts/libs/jquery.backstretch.min.js"></script>
     <!-- JS Custom Codes -->
     <script src="javascripts/custom/navmenu-init.js"></script>
     <script src="javascripts/custom/backstretch-init.js"></script>
     <script src="javascripts/custom/equalheights-init.js"></script>
     <script src="javascripts/custom/main.js"></script>
 
-    <script>
-        $(document).ready(function(){
-
-          $.backstretch([
-              "images/bg/ferris.jpg"
-          ]);
-
-        })
-    </script>
 
 
 </body>


### PR DESCRIPTION
about.html had an inline backstretch call referencing images/bg/ferris.jpg which does not exist. Removed the dead reference; backstretch-init.js (using the existing flowers.jpg) is retained for the page background.