### PR TITLE
fix: accessibility audit — WCAG improvements across all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -100,9 +100,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="#">About</a>
             <ul>
-              <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/about.html
+++ b/about.html
@@ -126,7 +126,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
         <section id="about" class="about pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -140,7 +140,7 @@
             <div class="container">
                 <div class="row">
                     <article class="text-left col-md-6">
-                        <h1 class="sub-heading"><span class="black font4">Ideas</span></h1>
+                        <h2 class="sub-heading"><span class="black font4">Ideas</span></h2>
                         <p class="promo-text dark font2 weight-light add-top-quarter">A thought, conception, or notion. An opinion, view, or belief. Any conception existing in the mind as a result of mental understanding, awareness, or activity. A plan of action; an intention.</p>
                     </article>
                     <article class="text-left col-md-6">
@@ -205,7 +205,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/about.html
+++ b/about.html
@@ -48,17 +48,18 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">
@@ -213,7 +214,7 @@
                     <div class="valign">
                         <ul class="foot-social">
                             <li>
-                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="linkedin"></a>
+                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="github"></a>
                             </li>
                             <li>
                                 <a href="https://www.linkedin.com/in/sbunch"><img src="images/social/in@2x.png"  width="40px" height="40px" title="linkedin" alt="linkedin"></a>

--- a/bookworm.html
+++ b/bookworm.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/bookworm.html
+++ b/bookworm.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">

--- a/bookworm.html
+++ b/bookworm.html
@@ -223,10 +223,11 @@
                     </article>
                     <article class="text-right col-md-6 white-bg text-center">
                         <div class="valign">
-                            <p class="credits font2 dark">Bunch of Ideas.
+                            <p class="credits font2 dark">Bunch of Ideas.</p>
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/bookworm.html
+++ b/bookworm.html
@@ -127,7 +127,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -205,7 +205,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/contact.html
+++ b/contact.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -65,11 +66,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">
@@ -171,12 +172,15 @@
                             </div>
                             <form name="myform" id="contactForm" action="https://formsubmit.co/872adc7bc5d9518ceacd52085354d094" enctype="multipart/form-data" method="post">
                                 <article>
+                                    <label for="name" class="sr-only">Your Name</label>
                                     <input type="text" placeholder="Your Name" id="name" name="name" size="100" class="border-form dark">
                                 </article>
                                 <article>
+                                    <label for="email" class="sr-only">Email address</label>
                                     <input type="text" placeholder="Email address" name="email" id="email" size="30" class="border-form dark">
                                 </article>
                                 <article>
+                                    <label for="msg" class="sr-only">Your Message</label>
                                     <textarea placeholder="Your Message" name="message" cols="40" rows="5" id="msg" class="border-form dark"></textarea>
                                     <div class="btn-wrap  text-left">
                                         <button class="btn btn-seven btn-seven-dark" id="submit" name="submit" type="submit">Send Message</button>
@@ -197,7 +201,7 @@
                     <div class="valign">
                         <ul class="foot-social">
                             <li>
-                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="linkedin"></a>
+                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="github"></a>
                             </li>
                             <li>
                                 <a href="https://www.linkedin.com/in/sbunch"><img src="images/social/in@2x.png"  width="40px" height="40px" title="linkedin" alt="linkedin"></a>

--- a/contact.html
+++ b/contact.html
@@ -139,7 +139,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="contact" class="contact pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -161,13 +161,13 @@
                 <div class="row">
                     <article class="col-md-12 main-caps text-left">
                         <div class="contact-item">
-                            <div class="alert alert-error error white-bg" id="fname">
+                            <div class="alert alert-error error white-bg" id="fname" role="alert" aria-live="polite" aria-atomic="true">
                                 <p class="dark">Name must not be empty</p>
                             </div>
-                            <div class="alert alert-error  error white-bg" id="fmail">
+                            <div class="alert alert-error  error white-bg" id="fmail" role="alert" aria-live="polite" aria-atomic="true">
                                 <p class="dark">Please provide a valid email</p>
                             </div>
-                            <div class="alert alert-error  error white-bg" id="fmsg">
+                            <div class="alert alert-error  error white-bg" id="fmsg" role="alert" aria-live="polite" aria-atomic="true">
                                 <p class="dark">Message should not be empty</p>
                             </div>
                             <form name="myform" id="contactForm" action="https://formsubmit.co/872adc7bc5d9518ceacd52085354d094" enctype="multipart/form-data" method="post">
@@ -192,7 +192,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/contact.html
+++ b/contact.html
@@ -88,7 +88,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -115,7 +114,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/damage.html
+++ b/damage.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/damage.html
+++ b/damage.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -207,7 +207,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/damage.html
+++ b/damage.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/dsc-boogies.html
+++ b/dsc-boogies.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/dsc-boogies.html
+++ b/dsc-boogies.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -187,7 +187,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/dsc-boogies.html
+++ b/dsc-boogies.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/dsc-five-reasons.html
+++ b/dsc-five-reasons.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/dsc-five-reasons.html
+++ b/dsc-five-reasons.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -199,7 +199,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/dsc-five-reasons.html
+++ b/dsc-five-reasons.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/error404.html
+++ b/error404.html
@@ -183,7 +183,7 @@
                 </article>
                 <article class="text-right col-md-6 white-bg text-center">
                     <div class="valign">
-                        <p class="credits font2 dark">Bunch of Ideas.
+                        <p class="credits font2 dark">Bunch of Ideas.</p>
                     </div>
                 </article>
             </div>

--- a/error404.html
+++ b/error404.html
@@ -91,7 +91,6 @@
                         <div class="sub-nav">
                             <a href="about.html">about</a>
                             <a href="services.html">services</a>
-                            <a href="resources.html">resources</a>
                         </div>
                     </li>
                     <li class="trigger-sub-nav">
@@ -120,7 +119,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/error404.html
+++ b/error404.html
@@ -54,6 +54,7 @@
 
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
 
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
@@ -62,11 +63,11 @@
 
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
 
 

--- a/error404.html
+++ b/error404.html
@@ -152,7 +152,7 @@
 
 
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
 
         <section id="about" class="about pad-bottom white-bg">
             <div class="container">
@@ -165,7 +165,7 @@
         </section>
 
 
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
 
     <section class="mastfoot space-top">

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                       <a class="main-nav-link" href="#">about</a>
                       <div class="sub-nav">
                         <a href="about.html">about</a>
+                        <a href="services.html">services</a>
                       </div>
                   </li>
                   <li class="trigger-sub-nav">

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
 
 
 <body class="page-home">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
   <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -71,11 +72,11 @@
 
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
 
 
@@ -188,7 +189,7 @@
                         <div class="valign">
                             <ul class="foot-social">
                               <li>
-                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="linkedin"></a>
+                                <a href="https://github.com/funbunch"><img src="images/social/git@2x.png"  width="40px" height="40px" title="github" alt="github"></a>
                             </li>
                                 <li><a href="https://www.linkedin.com/in/sbunch"><img src="images/social/in@2x.png" width="40px" height="40px" title="linkedin" alt="linkedin"></a></li>
                                 <li><a href="https://www.facebook.com/bunchofideas/"><img src="images/social/03@2x.png" width="40px" height="40px" title="facebook" alt="facebook"></a></li>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@
                       <a class="main-nav-link" href="#">about</a>
                       <div class="sub-nav">
                         <a href="about.html">about</a>
-                        <a href="resources.html">resources</a>
                       </div>
                   </li>
                   <li class="trigger-sub-nav">
@@ -130,7 +129,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 
 
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
 
     <section id="intro" class="intro intro-03 pad-bottom-half white-bg">
         <div class="container">
@@ -174,7 +174,7 @@
         </div>
     </section>
 
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
 
     <!-- mobile/tablet background image -->

--- a/javascripts/custom/navmenu-init.js
+++ b/javascripts/custom/navmenu-init.js
@@ -3,6 +3,7 @@
 $('.mobile-toggle').on('click', function() {
     if ($('.main-nav').hasClass('open-nav')) {
         $('.mobile-toggle span').removeClass('white-color');
+        $('.mobile-toggle').attr('aria-expanded', 'false').attr('aria-label', 'Open navigation menu');
         $('.main-nav').removeClass('open-nav');
         $('.masthead').removeClass('revealed');
             $('.menu-panel').stop().animate({
@@ -12,6 +13,7 @@ $('.mobile-toggle').on('click', function() {
                                 });
     } else {
         $('.mobile-toggle span').addClass('white-color');
+        $('.mobile-toggle').attr('aria-expanded', 'true').attr('aria-label', 'Close navigation menu');
         $('.main-nav').addClass('open-nav');
         $('.masthead').addClass('revealed');
        $('.menu-panel').stop().animate({

--- a/modaltest.html
+++ b/modaltest.html
@@ -46,17 +46,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/modaltest.html
+++ b/modaltest.html
@@ -126,7 +126,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -202,7 +202,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/modaltest.html
+++ b/modaltest.html
@@ -131,7 +131,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Deutsch </h1>
-                            <h3 class="font2 dark">Client: Volkswagen</h2>
+                            <h3 class="font2 dark">Client: Volkswagen</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -219,11 +219,11 @@
                     </article>
                     <article class="text-right col-md-6 white-bg text-center">
                         <div class="valign">
-                            <p class="credits font2 dark">Bunch of Ideas.
-                                <br/>Copyright &copy; 2016</p>
+                            <p class="credits font2 dark">Bunch of Ideas.<br/>Copyright &copy; 2016</p>
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/modaltest.html
+++ b/modaltest.html
@@ -75,7 +75,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -102,7 +101,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-1.html
+++ b/project-1.html
@@ -55,6 +55,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -65,11 +66,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-1.html
+++ b/project-1.html
@@ -88,7 +88,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -115,7 +114,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-1.html
+++ b/project-1.html
@@ -139,7 +139,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -211,7 +211,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-10.html
+++ b/project-10.html
@@ -85,7 +85,6 @@
                                 <a class="main-nav-link" href="#">About</a>
                                 <div class="sub-nav">
                                   <a href="about.html">about</a>
-                                   <a href="resources.html">resources</a>
                                  </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -112,7 +111,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-10.html
+++ b/project-10.html
@@ -141,7 +141,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Deutsch </h1>
-                            <h3 class="font2 dark">Client: HTC</h2>
+                            <h3 class="font2 dark">Client: HTC</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -229,6 +229,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-10.html
+++ b/project-10.html
@@ -136,7 +136,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -207,7 +207,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-10.html
+++ b/project-10.html
@@ -53,6 +53,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -63,11 +64,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-11.html
+++ b/project-11.html
@@ -141,7 +141,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Deutsch </h1>
-                            <h3 class="font2 dark">Client: Anthem</h2>
+                            <h3 class="font2 dark">Client: Anthem</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -228,6 +228,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-11.html
+++ b/project-11.html
@@ -53,6 +53,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -63,11 +64,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-11.html
+++ b/project-11.html
@@ -136,7 +136,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -206,7 +206,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-11.html
+++ b/project-11.html
@@ -85,7 +85,6 @@
                                 <a class="main-nav-link" href="#">About</a>
                                 <div class="sub-nav">
                                   <a href="about.html">about</a>
-                                  <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -112,7 +111,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-2.html
+++ b/project-2.html
@@ -89,7 +89,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -116,7 +115,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-2.html
+++ b/project-2.html
@@ -140,7 +140,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -219,7 +219,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-2.html
+++ b/project-2.html
@@ -56,6 +56,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -66,11 +67,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-3.html
+++ b/project-3.html
@@ -55,6 +55,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -65,11 +66,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">
@@ -230,6 +231,7 @@
                             <p class="credits font2 dark">Bunch of Ideas.</p>
                         </div>
                     </article>
+                </div>
         </div>
     </section>
     <!-- Core JS Libraries -->

--- a/project-3.html
+++ b/project-3.html
@@ -88,7 +88,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -115,7 +114,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-3.html
+++ b/project-3.html
@@ -139,7 +139,7 @@
     </header>
     <!-- masthead-section:ends -->
   <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -209,7 +209,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-4.html
+++ b/project-4.html
@@ -54,6 +54,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -64,11 +65,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-4.html
+++ b/project-4.html
@@ -87,7 +87,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -114,7 +113,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-4.html
+++ b/project-4.html
@@ -138,7 +138,7 @@
     </header>
     <!-- masthead-section:ends -->
      <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -210,7 +210,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-4.html
+++ b/project-4.html
@@ -143,7 +143,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Advisor Launchpad</h1>
-                            <h3 class="font2 dark">Client: JNS</h2>
+                            <h3 class="font2 dark">Client: JNS</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -231,6 +231,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-5.html
+++ b/project-5.html
@@ -228,6 +228,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-5.html
+++ b/project-5.html
@@ -54,6 +54,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -64,11 +65,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-5.html
+++ b/project-5.html
@@ -87,7 +87,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -114,7 +113,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-5.html
+++ b/project-5.html
@@ -138,7 +138,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -207,7 +207,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-6.html
+++ b/project-6.html
@@ -136,7 +136,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -213,7 +213,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-6.html
+++ b/project-6.html
@@ -141,7 +141,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Advisor Launchpad</h1>
-                            <h3 class="font2 dark">Client: Underwood</h2>
+                            <h3 class="font2 dark">Client: Underwood</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -234,6 +234,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-6.html
+++ b/project-6.html
@@ -52,6 +52,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -62,11 +63,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-6.html
+++ b/project-6.html
@@ -85,7 +85,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -112,7 +111,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-7.html
+++ b/project-7.html
@@ -228,6 +228,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-7.html
+++ b/project-7.html
@@ -86,7 +86,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -112,7 +111,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-7.html
+++ b/project-7.html
@@ -53,6 +53,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -63,11 +64,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-7.html
+++ b/project-7.html
@@ -136,7 +136,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -206,7 +206,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-8.html
+++ b/project-8.html
@@ -86,7 +86,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -113,7 +112,6 @@
              <ul>
                <li><a href="about.html">About</a></li>
                <li><a href="services.html">Services</a></li>
-               <li><a href="resources.html">Resources</a></li>
              </ul>
            </li>
            <li><a href="#">Portfolio</a>

--- a/project-8.html
+++ b/project-8.html
@@ -53,6 +53,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -63,11 +64,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-8.html
+++ b/project-8.html
@@ -137,7 +137,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -207,7 +207,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-9.html
+++ b/project-9.html
@@ -137,7 +137,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -209,7 +209,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-9.html
+++ b/project-9.html
@@ -53,6 +53,7 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -63,11 +64,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-9.html
+++ b/project-9.html
@@ -142,7 +142,7 @@
                     <article class="text-left col-md-12">
                         <div class="welcome add-top-quarter">
                             <h1 class="font3 black">Agency: Deutsch </h1>
-                            <h3 class="font2 dark">Client: Volkswagen</h2>
+                            <h3 class="font2 dark">Client: Volkswagen</h3>
                             <h2 class="font2 dark"><span class="font2 weight-light dark">Web</span></h2>
                         </div>
                     </article>
@@ -231,6 +231,7 @@
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/project-9.html
+++ b/project-9.html
@@ -86,7 +86,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -113,7 +112,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-dtv1.html
+++ b/project-dtv1.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-dtv1.html
+++ b/project-dtv1.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-dtv1.html
+++ b/project-dtv1.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
   <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -199,7 +199,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-dtv2.html
+++ b/project-dtv2.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-dtv2.html
+++ b/project-dtv2.html
@@ -103,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/project-dtv2.html
+++ b/project-dtv2.html
@@ -127,7 +127,7 @@
     </header>
     <!-- masthead-section:ends -->
   <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -198,7 +198,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-last.html
+++ b/project-last.html
@@ -126,7 +126,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -199,7 +199,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/project-last.html
+++ b/project-last.html
@@ -47,17 +47,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/project-last.html
+++ b/project-last.html
@@ -75,7 +75,6 @@
                               <a class="main-nav-link" href="#">about</a>
                               <div class="sub-nav">
                                 <a href="about.html">about</a>
-                                <a href="resources.html">resources</a>
                               </div>
                           </li>
                           <li class="trigger-sub-nav">
@@ -102,7 +101,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/qb-payments.html
+++ b/qb-payments.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/qb-payments.html
+++ b/qb-payments.html
@@ -216,10 +216,11 @@
                     </article>
                     <article class="text-right col-md-6 white-bg text-center">
                         <div class="valign">
-                            <p class="credits font2 dark">Bunch of Ideas.
+                            <p class="credits font2 dark">Bunch of Ideas.</p>
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/qb-payments.html
+++ b/qb-payments.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -199,7 +199,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/qb-payments.html
+++ b/qb-payments.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/qb-payroll.html
+++ b/qb-payroll.html
@@ -48,17 +48,18 @@
 </head>
 
 <body class="single-project-wrap">
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/qb-payroll.html
+++ b/qb-payroll.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="intro" class="intro single-project white-bg pad-project">
             <div class="container">
                 <div class="row">
@@ -206,7 +206,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid"> 

--- a/qb-payroll.html
+++ b/qb-payroll.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/qb-payroll.html
+++ b/qb-payroll.html
@@ -223,10 +223,11 @@
                     </article>
                     <article class="text-right col-md-6 white-bg text-center">
                         <div class="valign">
-                            <p class="credits font2 dark">Bunch of Ideas.
+                            <p class="credits font2 dark">Bunch of Ideas.</p>
                         </div>
                     </article>
         </div>
+    </div>
     </section>
     <!-- Core JS Libraries -->
     <script src="javascripts/libs/jquery.min.js" type="text/javascript"></script>

--- a/resources.html
+++ b/resources.html
@@ -149,7 +149,7 @@
 
 
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
 
 
 
@@ -200,7 +200,7 @@
         </section>
 
 
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
 
     <section class="mastfoot space-top">

--- a/resources.html
+++ b/resources.html
@@ -53,6 +53,7 @@
 
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
 
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
@@ -61,11 +62,11 @@
 
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
 
 

--- a/services.html
+++ b/services.html
@@ -77,7 +77,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -104,7 +103,6 @@
              <ul>
                <li><a href="about.html">About</a></li>
                <li><a href="services.html">Services</a></li>
-               <li><a href="resources.html">Resources</a></li>
              </ul>
            </li>
            <li><a href="#">Portfolio</a>

--- a/services.html
+++ b/services.html
@@ -128,7 +128,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-color">
         <section id="about" class="about pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -186,7 +186,7 @@
                 </div>
             </div>
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/services.html
+++ b/services.html
@@ -76,7 +76,6 @@
                                 <a class="main-nav-link" href="#">About</a>
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
-                                    <a href="services.html">services</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -102,7 +101,6 @@
            <li><a href="#">About</a>
              <ul>
                <li><a href="about.html">About</a></li>
-               <li><a href="services.html">Services</a></li>
              </ul>
            </li>
            <li><a href="#">Portfolio</a>
@@ -203,7 +201,7 @@
                 </article>
                 <article class="text-right col-md-6 white-bg text-center">
                     <div class="valign">
-                        <p class="credits font2 dark">Bunch of Ideas.
+                        <p class="credits font2 dark">Bunch of Ideas.</p>
                     </div>
                 </article>
             </div>

--- a/services.html
+++ b/services.html
@@ -48,17 +48,18 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -28,8 +28,18 @@ body
 a, a:hover, a:focus{
 	text-decoration: none;
 }
-a:focus {
-  outline: none;
+.skip-nav {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 9999;
+  padding: 8px 16px;
+  background: #000;
+  color: #fff;
+  font-size: 14px;
+}
+.skip-nav:focus {
+  top: 0;
 }
 .animated{
 	visibility: hidden;

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -1076,3 +1076,26 @@ section.map-wrap {
         transform: none !important;
     }
 }
+
+/*-------------------------------------------------------------------------------------------------------------------------------*/
+/* ACCESSIBILITY — COLOR CONTRAST FIXES */
+/* less-compiled.css sets a:hover{color:#FFE44A} globally — yellow on white is 1.28:1 (FAIL). */
+/* These overrides restore readable contrast on light backgrounds. Nav hover stays yellow */
+/* because .main-nav-menu a:hover has its own rule on the dark panel background. */
+/*-------------------------------------------------------------------------------------------------------------------------------*/
+
+/* Text selection: keep yellow bg, swap white text → dark (9.75:1 AAA) */
+::selection { background-color: #FFE44A; color: #343434 !important; }
+::-moz-selection { background-color: #FFE44A; color: #343434 !important; }
+
+/* Link hover in content areas: #mastwrap ID gives higher specificity than global a:hover */
+#mastwrap a:hover {
+    color: #343434;
+    text-decoration: underline;
+}
+
+/* Works filter active state: yellow (#FFE44A) on off-white is 1.14:1 (FAIL). */
+/* #7A6000 dark gold = 5.36:1 on off-white, 6.00:1 on white — AA both. */
+.works-filter li a.active > span {
+    color: #7A6000 !important;
+}

--- a/stylesheets/navmenu.css
+++ b/stylesheets/navmenu.css
@@ -22,6 +22,9 @@
   top:40px;
   width: 30px;
   z-index: 1000;
+  background: none;
+  border: none;
+  padding: 0;
   -webkit-transition: all .4s ease-in-out;
      -moz-transition: all .4s ease-in-out;
     -ms-transition: all .4s ease-in-out;

--- a/thanks.html
+++ b/thanks.html
@@ -54,6 +54,7 @@
 
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
 
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
@@ -62,11 +63,11 @@
 
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-    	<div class="mobile-toggle">
+    	<button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
     	    <span></span>
     	    <span></span>
     	    <span></span>
-    	</div>
+        </button>
     </div>
 
 

--- a/thanks.html
+++ b/thanks.html
@@ -141,6 +141,7 @@
                     <a href="index.html"><img alt="Bunch of Ideas" title="Bunch of Ideas" class="main-logo img-responsive" src="images/logo@2x.png" width="600" height="70"/></a>
                 </article>
     	</div>
+    	</div>
 
     </header>
     <!-- masthead-section:ends -->
@@ -181,7 +182,7 @@
                 </article>
                 <article class="text-right col-md-6 white-bg text-center">
                     <div class="valign">
-                        <p class="credits font2 dark">Bunch of Ideas.
+                        <p class="credits font2 dark">Bunch of Ideas.</p>
                     </div>
                 </article>
     		</div>

--- a/thanks.html
+++ b/thanks.html
@@ -88,7 +88,6 @@
                             <div class="sub-nav">
                                 <a href="about.html">about</a>
                                 <a href="services.html">services</a>
-                                <a href="resources.html">resources</a>
                             </div>
                         </li>
                         <li class="trigger-sub-nav">
@@ -119,7 +118,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/thanks.html
+++ b/thanks.html
@@ -150,7 +150,7 @@
 
 
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-white">
 
         <section id="about" class="about pad-bottom white-bg">
         	<div class="container">
@@ -163,7 +163,7 @@
         </section>
 
 
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
 
     <section class="mastfoot space-top">

--- a/works-grid-0.html
+++ b/works-grid-0.html
@@ -129,7 +129,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
         <section id="woks-head" class="woks-head pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -269,7 +269,7 @@
             </div>
             <!-- container : ends -->
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/works-grid-0.html
+++ b/works-grid-0.html
@@ -286,7 +286,7 @@
                 </article>
                 <article class="text-right col-md-6 white-bg text-center">
                     <div class="valign">
-                        <p class="credits font2 dark">Bunch of Ideas.
+                        <p class="credits font2 dark">Bunch of Ideas.</p>
 
                     </div>
                 </article>

--- a/works-grid-0.html
+++ b/works-grid-0.html
@@ -49,17 +49,18 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/works-grid-0.html
+++ b/works-grid-0.html
@@ -78,7 +78,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -105,7 +104,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/works-grid-1.html
+++ b/works-grid-1.html
@@ -272,7 +272,7 @@
                 </article>
                 <article class="text-right col-md-6 white-bg text-center">
                     <div class="valign">
-                        <p class="credits font2 dark">Bunch of Ideas.
+                        <p class="credits font2 dark">Bunch of Ideas.</p>
 
                     </div>
                 </article>

--- a/works-grid-1.html
+++ b/works-grid-1.html
@@ -74,7 +74,6 @@
                                 <div class="sub-nav">
                                     <a href="about.html">about</a>
                                     <a href="services.html">services</a>
-                                    <a href="resources.html">resources</a>
                                 </div>
                             </li>
                             <li class="trigger-sub-nav">
@@ -101,7 +100,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>

--- a/works-grid-1.html
+++ b/works-grid-1.html
@@ -45,17 +45,18 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <div class="sticky-border sticky-border-top"></div>
     <div class="sticky-border sticky-border-right"></div>
     <div class="sticky-border sticky-border-bottom"></div>
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/works-grid-1.html
+++ b/works-grid-1.html
@@ -125,7 +125,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
         <section id="woks-head" class="woks-head pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -255,7 +255,7 @@
             </div>
             <!-- container : ends -->
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/works-grid.html
+++ b/works-grid.html
@@ -52,6 +52,7 @@
 </head>
 
 <body>
+    <a href="#mastwrap" class="skip-nav">Skip to main content</a>
     <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MHPKL43J"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -62,11 +63,11 @@
     <div class="sticky-border sticky-border-left"></div>
     <!-- main navigation trigger -->
     <div class="main-nav visible-lg">
-        <div class="mobile-toggle">
+        <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
-        </div>
+        </button>
     </div>
     <!-- main menu : starts -->
     <section class="menu-panel menu-bg fullheight">

--- a/works-grid.html
+++ b/works-grid.html
@@ -135,7 +135,7 @@
     </header>
     <!-- masthead-section:ends -->
     <!-- Master Wrap : starts -->
-    <section id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
+    <main id="mastwrap" class="mastwrap slant-bottom slant-bottom-offwhite">
         <section id="woks-head" class="woks-head pad-bottom white-bg">
             <div class="container">
                 <div class="row">
@@ -151,10 +151,10 @@
                     <div id="works-container" class="works-container container clearfix">
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/bookworm-tb@2x.jpg" />
+                            <img alt="Bookworm Reads web project" title="Bookworm Reads" class="img-responsive" src="images/work/bookworm-tb@2x.jpg" />
                                 <a href="bookworm.html">
                                     <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Bookworm Reads</h3>
                                     <p class="dark"><span class="dark">Web</span></p>
                                 </div>
                             </a>
@@ -162,10 +162,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/postparty-tb@2x.jpg" />
+                            <img alt="Epic Games project by Damage agency" title="Epic Games" class="img-responsive" src="images/work/postparty-tb@2x.jpg" />
                                 <a href="damage.html">
                                     <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Epic Games</h3>
                                     <p class="dark"><span class="dark">Web</span></p>
                                 </div>
                             </a>
@@ -173,10 +173,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                        <img alt="" title="" class="img-responsive" src="images/work/payroll-tb@2x.jpg" />
+                        <img alt="Intuit QuickBooks Payroll web project" title="Intuit QuickBooks Payroll" class="img-responsive" src="images/work/payroll-tb@2x.jpg" />
                             <a href="qb-payroll.html">
                                 <div class="works-item-inner valign">
-                                <h3 class="dark">Project Info</h3>
+                                <h3 class="dark">Intuit — QuickBooks Payroll</h3>
                                 <p class="dark"><span class="dark">Web</span></p>
                             </div>
                         </a>
@@ -184,10 +184,10 @@
                     <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/payments-tb.jpg" />
+                            <img alt="Intuit QuickBooks Payments web project" title="Intuit QuickBooks Payments" class="img-responsive" src="images/work/payments-tb.jpg" />
                                 <a href="qb-payments.html">
                                     <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Intuit — QuickBooks Payments</h3>
                                     <p class="dark"><span class="dark">Web</span></p>
                                 </div>
                             </a>
@@ -195,10 +195,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/dsc-five-reasons-sm.jpg" />
+                            <img alt="Dollar Shave Club web project" title="Dollar Shave Club" class="img-responsive" src="images/work/dsc-five-reasons-sm.jpg" />
                                 <a href="dsc-five-reasons.html">
                                     <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Dollar Shave Club</h3>
                                     <p class="dark"><span class="dark">Web</span></p>
                                 </div>
                             </a>
@@ -206,10 +206,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/dsc-hair-paste.jpg" />
+                            <img alt="Dollar Shave Club email project" title="Dollar Shave Club" class="img-responsive" src="images/work/dsc-hair-paste.jpg" />
                                 <a href="dsc-boogies.html">
                                     <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Dollar Shave Club — Email</h3>
                                     <p class="dark"><span class="dark">Email</span></p>
                                 </div>
                             </a>
@@ -217,10 +217,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                        <img alt="" title="" class="img-responsive" src="images/work/shapeofwater.jpg" />
+                        <img alt="Fox Searchlight single page website by TVGLa" title="Fox Searchlight" class="img-responsive" src="images/work/shapeofwater.jpg" />
                         <a href="project-2.html">
                             <div class="works-item-inner valign">
-                                <h3 class="dark">Project Info</h3>
+                                <h3 class="dark">Fox Searchlight</h3>
                                 <p class="dark"><span class="dark">Single Page Website</span></p>
                             </div>
                         </a>
@@ -228,10 +228,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                           <img alt="" title="" class="img-responsive" src="images/work/fox-3bb.jpg" />
+                           <img alt="Fox single page website by TVGLa" title="Fox" class="img-responsive" src="images/work/fox-3bb.jpg" />
                            <a href="project-1.html">
                                <div class="works-item-inner valign">
-                                   <h3 class="dark">Project Info</h3>
+                                   <h3 class="dark">Fox</h3>
                                    <p class="dark"><span class="dark">Single Page Website</span></p>
                                </div>
                            </a>
@@ -239,10 +239,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                        <div class="works-item works-item-one-third info logos ui">
-                           <img alt="" title="" class="img-responsive" src="images/work/welcome-sm.jpg" />
+                           <img alt="Responsive HTML email by Kern agency" title="Kern Agency" class="img-responsive" src="images/work/welcome-sm.jpg" />
                            <a href="project-dtv2.html">
                                <div class="works-item-inner valign">
-                                   <h3 class="dark">Project Info</h3>
+                                   <h3 class="dark">Kern Agency</h3>
                                    <p class="dark"><span class="dark">Email</span></p>
                                </div>
                            </a>
@@ -250,10 +250,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                        <div class="works-item works-item-one-third info logos ui">
-                           <img alt="" title="" class="img-responsive" src="images/work/smarsh.jpg" />
+                           <img alt="Smarsh website" title="Smarsh" class="img-responsive" src="images/work/smarsh.jpg" />
                            <a href="project-3.html">
                                <div class="works-item-inner valign">
-                                   <h3 class="dark">Project Info</h3>
+                                   <h3 class="dark">Smarsh</h3>
                                    <p class="dark"><span class="dark">Website</span></p>
                                </div>
                            </a>
@@ -261,10 +261,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/JNS.jpg" />
+                            <img alt="JNS website by Advisor Launchpad" title="JNS" class="img-responsive" src="images/work/JNS.jpg" />
                             <a href="project-4.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">JNS</h3>
                                     <p class="dark"><span class="dark">Website</span></p>
                                 </div>
                             </a>
@@ -272,10 +272,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/highpointe.jpg" />
+                            <img alt="Highpointe Financial Group website" title="Highpointe Financial" class="img-responsive" src="images/work/highpointe.jpg" />
                             <a href="project-5.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Highpointe Financial</h3>
                                     <p class="dark"><span class="dark">Website</span></p>
                                 </div>
                             </a>
@@ -283,10 +283,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/underwood.jpg" />
+                            <img alt="Underwood website by Advisor Launchpad" title="Underwood" class="img-responsive" src="images/work/underwood.jpg" />
                             <a href="project-6.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Underwood</h3>
                                     <p class="dark"><span class="dark">Website</span></p>
                                 </div>
                             </a>
@@ -294,10 +294,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/crownpeak.jpg" />
+                            <img alt="Crownpeak website" title="Crownpeak" class="img-responsive" src="images/work/crownpeak.jpg" />
                             <a href="project-7.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Crownpeak</h3>
                                     <p class="dark"><span class="dark">Website</span></p>
                                 </div>
                             </a>
@@ -305,10 +305,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/guess-email.jpg" />
+                            <img alt="Guess email campaign" title="Guess" class="img-responsive" src="images/work/guess-email.jpg" />
                             <a href="project-8.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Guess</h3>
                                     <p class="dark"><span class="dark">Email</span></p>
                                 </div>
                             </a>
@@ -316,10 +316,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/vw.jpg" />
+                            <img alt="Volkswagen website by Deutsch" title="Volkswagen" class="img-responsive" src="images/work/vw.jpg" />
                             <a href="project-9.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">Volkswagen</h3>
                                     <p class="dark"><span class="dark">Website Maintenance</span></p>
                                 </div>
                             </a>
@@ -327,10 +327,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                         <div class="works-item works-item-one-third info logos ui">
-                            <img alt="" title="" class="img-responsive" src="images/work/htc.jpg" />
+                            <img alt="HTC website by Deutsch" title="HTC" class="img-responsive" src="images/work/htc.jpg" />
                             <a href="project-10.html">
                                 <div class="works-item-inner valign">
-                                    <h3 class="dark">Project Info</h3>
+                                    <h3 class="dark">HTC</h3>
                                     <p class="dark"><span class="dark">Website Maintenance</span></p>
                                 </div>
                             </a>
@@ -338,10 +338,10 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                           <div class="works-item works-item-one-third info logos ui">
-                              <img alt="" title="" class="img-responsive" src="images/work/anthem.jpg" />
+                              <img alt="Anthem website by Deutsch" title="Anthem" class="img-responsive" src="images/work/anthem.jpg" />
                               <a href="project-11.html">
                                   <div class="works-item-inner valign">
-                                      <h3 class="dark">Project Info</h3>
+                                      <h3 class="dark">Anthem</h3>
                                       <p class="dark"><span class="dark">Website</span></p>
                                   </div>
                               </a>
@@ -349,7 +349,7 @@
                         <!-- end : works-item -->
                         <!-- start : works-item -->
                          <!-- <div class="works-item works-item-one-third info logos ui">
-                             <img alt="" title="" class="img-responsive" src="images/work/kastner.jpg" />
+                             <img alt="Anthem website by Deutsch" title="Anthem" class="img-responsive" src="images/work/kastner.jpg" />
                              <a href="project-last.html">
                                  <div class="works-item-inner valign">
                                      <h3 class="dark">Project Info</h3>
@@ -364,7 +364,7 @@
             </div>
             <!-- container : ends -->
         </section>
-    </section>
+    </main>
     <!-- Master Wrap : ends -->
     <section class="mastfoot space-top">
         <div class="container-fluid">

--- a/works-grid.html
+++ b/works-grid.html
@@ -111,7 +111,6 @@
             <ul>
               <li><a href="about.html">About</a></li>
               <li><a href="services.html">Services</a></li>
-              <li><a href="resources.html">Resources</a></li>
             </ul>
           </li>
           <li><a href="#">Portfolio</a>


### PR DESCRIPTION
## Summary

Full accessibility audit and fix pass covering all main pages.

**WCAG failures resolved:**
- Remove `a:focus { outline: none }` — restores keyboard focus indicators sitewide (2.4.7)
- Convert hamburger toggle from `<div>` to `<button>` with `aria-label` / `aria-expanded` on all 31 pages (4.1.2)
- Add skip navigation link to all pages pointing to `#mastwrap` (2.4.1)
- Add visually-hidden `<label>` elements to all contact form inputs (1.3.1)
- Add `role="alert"` / `aria-live` to contact form error messages (3.3.1)
- Add `<main>` landmark replacing `<section id="mastwrap">` on all pages (1.3.1)
- Fix duplicate `<h1>` on about.html — demote "Ideas" to `<h2>` (1.3.1)
- Add meaningful alt text and descriptive headings to all 18 portfolio items (1.1.1, 2.4.6)
- Fix GitHub icon alt text from "linkedin" → "github" on all pages (1.1.1)
- Fix `::selection` text contrast: white on yellow (1.28:1) → dark on yellow (9.75:1) (1.4.3)
- Fix `a:hover` contrast in content areas: yellow on white (1.28:1) → dark + underline (12.45:1) (1.4.3)

**Nav cleanup:**
- Remove resources.html from all nav menus sitewide (desktop + mobile)
- Remove self-links on about.html and services.html mobile nav
- Add services link to About sub-nav on homepage desktop nav

**HTML fixes:**
- Fix `<h3>…</h2>` tag mismatch on 6 project pages
- Add missing `</p>` in footer credits on 8 pages
- Add missing `</div>` for container-fluid in mastfoot on 11 pages
- Fix unclosed `<div>` in thanks.html header
- Fix stray `</p>` in modaltest.html

## Test plan

- [ ] Tab through each main page — focus ring should be visible on all interactive elements
- [ ] Click hamburger toggle — aria-expanded should flip, label should change to "Close navigation menu"
- [ ] Press Tab from page load — skip link should appear at top
- [ ] Hover links in content areas — should underline and turn dark (not yellow)
- [ ] Highlight text — selection should show dark text on yellow background
- [ ] Check mobile nav on about.html — no self-link, no resources link
- [ ] Check desktop nav on homepage — About sub-nav shows "about" and "services"
- [ ] Check works-grid.html — each portfolio item has a descriptive heading and alt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)